### PR TITLE
ALS-3738 - Remove deprecated divisional groups

### DIFF
--- a/groups/fileshare-groups.ldif.j2
+++ b/groups/fileshare-groups.ldif.j2
@@ -311,18 +311,6 @@ description: UPW Seetec FileShare Write Access
 ###########################################
 # NPS - DIV01/NorthWest/GreaterManchester #
 ###########################################
-dn: cn=RES-FS-NorthWest-NPS-R,ou=Fileshare,{{ ldap_config.base_groups }}
-objectClass: groupOfNames
-member: cn=placeholder
-cn: RES-FS-NorthWest-NPS-R
-description: ZZ DO NOT USE - NorthWest-NPS FileShare Read Access
-
-dn: cn=RES-FS-NorthWest-NPS-RW,ou=Fileshare,{{ ldap_config.base_groups }}
-objectClass: groupOfNames
-member: cn=placeholder
-cn: RES-FS-NorthWest-NPS-RW
-description: ZZ DO NOT USE - NorthWest-NPS FileShare Write Access
-
 dn: cn=RES-FS-N50-GreaterManchester-NPS-R,ou=Fileshare,{{ ldap_config.base_groups }}
 objectClass: groupOfNames
 member: cn=placeholder
@@ -351,19 +339,6 @@ description: NorthWest-NPS FileShare Write Access
 ###########################################
 # NPS - DIV04/East Midlands/West Midlands #
 ###########################################
-
-dn: cn=RES-FS-Midlands-NPS-R,ou=Fileshare,{{ ldap_config.base_groups }}
-objectClass: groupOfNames
-member: cn=placeholder
-cn: RES-FS-Midlands-NPS-R
-description: ZZ DO NOT USE - Midlands-NPS FileShare Read Access
-
-dn: cn=RES-FS-Midlands-NPS-RW,ou=Fileshare,{{ ldap_config.base_groups }}
-objectClass: groupOfNames
-member: cn=placeholder
-cn: RES-FS-Midlands-NPS-RW
-description: ZZ DO NOT USE - Midlands-NPS FileShare Write Access
-
 dn: cn=RES-FS-N52-WestMidlands-NPS-R,ou=Fileshare,{{ ldap_config.base_groups }}
 objectClass: groupOfNames
 member: cn=placeholder
@@ -416,22 +391,9 @@ member: cn=placeholder
 cn: RES-FS-N55-YorkshireandHumberside-NPS-RW
 description: YorkshireandHumberside-NPS FileShare Write Access
 
-dn: cn=RES-FS-NorthEast-NPS-R,ou=Fileshare,{{ ldap_config.base_groups }}
-objectClass: groupOfNames
-member: cn=placeholder
-cn: RES-FS-NorthEast-NPS-R
-description: ZZ DO NOT USE - NorthEast-NPS FileShare Read Access
-
-dn: cn=RES-FS-NorthEast-NPS-RW,ou=Fileshare,{{ ldap_config.base_groups }}
-objectClass: groupOfNames
-member: cn=placeholder
-cn: RES-FS-NorthEast-NPS-RW
-description: ZZ DO NOT USE - NorthEast-NPS FileShare Write Access
-
 #################################################
 # NPS - DIV06/EastofEngland/KentSurreyandSussex #
 #################################################
-
 dn: cn=RES-FS-N56-EastofEngland-NPS-R,ou=Fileshare,{{ ldap_config.base_groups }}
 objectClass: groupOfNames
 member: cn=placeholder
@@ -456,22 +418,9 @@ member: cn=placeholder
 cn: RES-FS-N57-KentSurreyandSussex-NPS-RW
 description: KentSurreyandSussex-NPS FileShare Write Access
 
-dn: cn=RES-FS-SouthEastandEastern-NPS-R,ou=Fileshare,{{ ldap_config.base_groups }}
-objectClass: groupOfNames
-member: cn=placeholder
-cn: RES-FS-SouthEastandEastern-NPS-R
-description: ZZ DO NOT USE - SouthEastandEastern-NPS FileShare Read Access
-
-dn: cn=RES-FS-SouthEastandEastern-NPS-RW,ou=Fileshare,{{ ldap_config.base_groups }}
-objectClass: groupOfNames
-member: cn=placeholder
-cn: RES-FS-SouthEastandEastern-NPS-RW
-description: ZZ DO NOT USE - SouthEastandEastern-NPS FileShare Write Access
-
 ######################################
 # NPS - DIV05/SouthWest/SouthCentral #
 ######################################
-
 dn: cn=RES-FS-N58-SouthWest-NPS-R,ou=Fileshare,{{ ldap_config.base_groups }}
 objectClass: groupOfNames
 member: cn=placeholder
@@ -495,18 +444,6 @@ objectClass: groupOfNames
 member: cn=placeholder
 cn: RES-FS-N59-SouthCentral-NPS-RW
 description: SouthCentral-NPS FileShare Write Access
-
-dn: cn=RES-FS-SouthWestandSouthCentral-NPS-R,ou=Fileshare,{{ ldap_config.base_groups }}
-objectClass: groupOfNames
-member: cn=placeholder
-cn: RES-FS-SouthWestandSouthCentral-NPS-R
-description: ZZ DO NOT USE - SouthWestandSouthCentral-NPS FileShare Read Access
-
-dn: cn=RES-FS-SouthWestandSouthCentral-NPS-RW,ou=Fileshare,{{ ldap_config.base_groups }}
-objectClass: groupOfNames
-member: cn=placeholder
-cn: RES-FS-SouthWestandSouthCentral-NPS-RW
-description: ZZ DO NOT USE - SouthWestandSouthCentral-NPS FileShare Write Access
 
 ###########################################
 # Central groups                          #
@@ -535,32 +472,3 @@ objectClass: groupOfNames
 member: cn=placeholder
 cn: RES-FS-NSD-NPS-RW
 description: RES-FS-NSD-NPS-RW
-
-
-###########################################
-# NPS - Regional groups not in use yet    #
-###########################################
-
-dn: cn=RES-FS-N03-Wales-NPS-R,ou=Fileshare,{{ ldap_config.base_groups }}
-objectClass: groupOfNames
-member: cn=placeholder
-cn: RES-FS-N03-Wales-NPS-R
-description: ZZ DO NOT USE - Wales-NPS FileShare Read Access
-
-dn: cn=RES-FS-N03-Wales-NPS-RW,ou=Fileshare,{{ ldap_config.base_groups }}
-objectClass: groupOfNames
-member: cn=placeholder
-cn: RES-FS-N03-Wales-NPS-RW
-description: ZZ DO NOT USE - Wales-NPS FileShare Write Access
-
-dn: cn=RES-FS-N07-London-NPS-R,ou=Fileshare,{{ ldap_config.base_groups }}
-objectClass: groupOfNames
-member: cn=placeholder
-cn: RES-FS-N07-London-NPS-R
-description: ZZ DO NOT USE - London-NPS FileShare Read Access
-
-dn: cn=RES-FS-N07-London-NPS-RW,ou=Fileshare,{{ ldap_config.base_groups }}
-objectClass: groupOfNames
-member: cn=placeholder
-cn: RES-FS-N07-London-NPS-RW
-description: ZZ DO NOT USE - London-NPS FileShare Write Access

--- a/groups/reporting-groups.ldif.j2
+++ b/groups/reporting-groups.ldif.j2
@@ -1061,24 +1061,6 @@ description: RES-APP-CPA15-ADM-NDMIS CPA15 Folder Content auth Report Admins
 ###########################################
 # NPS - DIV01/NorthWest/GreaterManchester #
 ###########################################
-dn: cn=USR-DIV01-NDMIS Reporting ADMIN group,ou=NDMIS-Reporting,{{ ldap_config.base_groups }}
-cn: USR-DIV01-NDMIS Reporting ADMIN group
-description: ZZ DO NOT USE - USR-DIV01-NDMIS Reporting ADMIN group
-objectClass: groupOfNames
-member: cn=placeholder
-
-dn: cn=USR-DIV01-NDMIS Reporting users group,ou=NDMIS-Reporting,{{ ldap_config.base_groups }}
-cn: USR-DIV01-NDMIS Reporting users group
-description: ZZ DO NOT USE - USR-DIV01-NDMIS Reporting users group
-objectClass: groupOfNames
-member: cn=placeholder
-
-dn: cn=USR-DIV01-NDMIS-MANAGERS Reporting users group,ou=NDMIS-Reporting,{{ ldap_config.base_groups }}
-cn: USR-DIV01-NDMIS-MANAGERS Reporting users group
-description: ZZ DO NOT USE - USR-DIV01-NDMIS-MANAGERS Reporting users group
-objectClass: groupOfNames
-member: cn=placeholder
-
 dn: cn=USR-ALL-REG-Access to the NDMIS REGIONAL Reports Folder,ou=NDMIS-Reporting,{{ ldap_config.base_groups }}
 cn: USR-ALL-REG-Access to the NDMIS REGIONAL Reports Folder
 description: USR-ALL-REG-Access to the NDMIS REGIONAL Reports Folder
@@ -1124,18 +1106,6 @@ member: cn=placeholder
 ###########################################
 # NPS - DIV04/East Midlands/West Midlands #
 ###########################################
-dn: cn=USR-DIV04-NDMIS Reporting ADMIN group,ou=NDMIS-Reporting,{{ ldap_config.base_groups }}
-cn: USR-DIV04-NDMIS Reporting ADMIN group
-description: ZZ DO NOT USE - USR-DIV04-NDMIS Reporting ADMIN group
-objectClass: groupOfNames
-member: cn=placeholder
-
-dn: cn=USR-DIV04-NDMIS Reporting users group,ou=NDMIS-Reporting,{{ ldap_config.base_groups }}
-cn: USR-DIV04-NDMIS Reporting users group
-description: ZZ DO NOT USE - USR-DIV04-NDMIS Reporting users group
-objectClass: groupOfNames
-member: cn=placeholder
-
 dn: cn=USR-DIV04-NDMIS-MANAGERS Reporting users group,ou=NDMIS-Reporting,{{ ldap_config.base_groups }}
 cn: USR-DIV04-NDMIS-MANAGERS Reporting users group
 description: USR-DIV04-NDMIS-MANAGERS Reporting users group
@@ -1181,25 +1151,6 @@ member: cn=placeholder
 ################################################
 # NPS - DIV02/NorthEast/YorkshireandHumberside #
 ################################################
-
-dn: cn=USR-DIV02-NDMIS Reporting ADMIN group,ou=NDMIS-Reporting,{{ ldap_config.base_groups }}
-cn: USR-DIV02-NDMIS Reporting ADMIN group
-description: ZZ DO NOT USE - USR-DIV02-NDMIS Reporting ADMIN group
-objectClass: groupOfNames
-member: cn=placeholder
-
-dn: cn=USR-DIV02-NDMIS Reporting users group,ou=NDMIS-Reporting,{{ ldap_config.base_groups }}
-cn: USR-DIV02-NDMIS Reporting users group
-description: ZZ DO NOT USE - USR-DIV02-NDMIS Reporting users group
-objectClass: groupOfNames
-member: cn=placeholder
-
-dn: cn=USR-DIV02-NDMIS-MANAGERS Reporting users group,ou=NDMIS-Reporting,{{ ldap_config.base_groups }}
-cn: USR-DIV02-NDMIS-MANAGERS Reporting users group
-description: ZZ DO NOT USE - USR-DIV02-NDMIS-MANAGERS Reporting users group
-objectClass: groupOfNames
-member: cn=placeholder
-
 dn: cn=USR-REG-N54-NDMIS-WRITER Reporting group,ou=NDMIS-Reporting,{{ ldap_config.base_groups }}
 cn: USR-REG-N54-NDMIS-WRITER Reporting group
 description: USR-REG-N54-NDMIS-WRITER Reporting group
@@ -1239,31 +1190,6 @@ member: cn=placeholder
 #################################################
 # NPS - DIV06/EastofEngland/KentSurreyandSussex #
 #################################################
-
-dn: cn=USR-DIV06-NDMIS Reporting ADMIN group,ou=NDMIS-Reporting,{{ ldap_config.base_groups }}
-cn: USR-DIV06-NDMIS Reporting ADMIN group
-description: ZZ DO NOT USE - USR-DIV06-NDMIS Reporting ADMIN group
-objectClass: groupOfNames
-member: cn=placeholder
-
-dn: cn=USR-DIV06-NDMIS Reporting users group,ou=NDMIS-Reporting,{{ ldap_config.base_groups }}
-cn: USR-DIV06-NDMIS Reporting users group
-description: ZZ DO NOT USE - USR-DIV06-NDMIS Reporting users group
-objectClass: groupOfNames
-member: cn=placeholder
-
-dn: cn=USR-DIV06-NDMIS-MANAGERS Reporting users group,ou=NDMIS-Reporting,{{ ldap_config.base_groups }}
-cn: USR-DIV06-NDMIS-MANAGERS Reporting users group
-description: ZZ DO NOT USE - USR-DIV06-NDMIS-MANAGERS Reporting users group
-objectClass: groupOfNames
-member: cn=placeholder
-
-dn: cn=USR-REG-N56-NDMIS-WRITER Reporting group,ou=NDMIS-Reporting,{{ ldap_config.base_groups }}
-cn: USR-REG-N56-NDMIS-WRITER Reporting group
-description: USR-REG-N56-NDMIS-WRITER Reporting group
-objectClass: groupOfNames
-member: cn=placeholder
-
 dn: cn=USR-REG-N56-NDMIS-MANAGER Reporting group,ou=NDMIS-Reporting,{{ ldap_config.base_groups }}
 cn: USR-REG-N56-NDMIS-MANAGER Reporting group
 description: USR-REG-N56-NDMIS-MANAGER Reporting group
@@ -1297,25 +1223,6 @@ member: cn=placeholder
 ######################################
 # NPS - DIV05/SouthWest/SouthCentral #
 ######################################
-
-dn: cn=USR-DIV05-NDMIS Reporting ADMIN group,ou=NDMIS-Reporting,{{ ldap_config.base_groups }}
-cn: USR-DIV05-NDMIS Reporting ADMIN group
-description: ZZ DO NOT USE - USR-DIV05-NDMIS Reporting ADMIN group
-objectClass: groupOfNames
-member: cn=placeholder
-
-dn: cn=USR-DIV05-NDMIS-MANAGERS Reporting users group,ou=NDMIS-Reporting,{{ ldap_config.base_groups }}
-cn: USR-DIV05-NDMIS-MANAGERS Reporting users group
-description: ZZ DO NOT USE - USR-DIV05-NDMIS-MANAGERS Reporting users group
-objectClass: groupOfNames
-member: cn=placeholder
-
-dn: cn=USR-DIV05-NDMIS Reporting users group,ou=NDMIS-Reporting,{{ ldap_config.base_groups }}
-cn: USR-DIV05-NDMIS Reporting users group
-description: ZZ DO NOT USE - USR-DIV05-NDMIS Reporting users group
-objectClass: groupOfNames
-member: cn=placeholder
-
 dn: cn=USR-REG-N58-NDMIS-WRITER Reporting group,ou=NDMIS-Reporting,{{ ldap_config.base_groups }}
 cn: USR-REG-N58-NDMIS-WRITER Reporting group
 description: USR-REG-N58-NDMIS-WRITER Reporting group
@@ -1413,45 +1320,5 @@ member: cn=placeholder
 dn: cn=USR-EPS-NDMIS-WRITER Reporting group,ou=NDMIS-Reporting,{{ ldap_config.base_groups }}
 cn: USR-EPS-NDMIS-WRITER Reporting group
 description: USR-EPS-NDMIS-WRITER Reporting group
-objectClass: groupOfNames
-member: cn=placeholder
-
-###########################################
-# NPS - Regional groups not in use        #
-###########################################
-
-dn: cn=USR-REG-N03-NDMIS-WRITER Reporting group,ou=NDMIS-Reporting,{{ ldap_config.base_groups }}
-cn: USR-REG-N03-NDMIS-WRITER Reporting group
-description: ZZ DO NOT USE - USR-REG-N03-NDMIS-WRITER Reporting group
-objectClass: groupOfNames
-member: cn=placeholder
-
-dn: cn=USR-REG-N03-NDMIS-MANAGER Reporting group,ou=NDMIS-Reporting,{{ ldap_config.base_groups }}
-cn: USR-REG-N03-NDMIS-MANAGER Reporting group
-description: ZZ DO NOT USE - USR-REG-N03-NDMIS-MANAGER Reporting group
-objectClass: groupOfNames
-member: cn=placeholder
-
-dn: cn=USR-REG-N03-NDMIS-READER Reporting group,ou=NDMIS-Reporting,{{ ldap_config.base_groups }}
-cn: USR-REG-N03-NDMIS-READER Reporting group
-description: ZZ DO NOT USE - USR-REG-N03-NDMIS-READER Reporting group
-objectClass: groupOfNames
-member: cn=placeholder
-
-dn: cn=USR-REG-N07-NDMIS-WRITER Reporting group,ou=NDMIS-Reporting,{{ ldap_config.base_groups }}
-cn: USR-REG-N07-NDMIS-WRITER Reporting group
-description: ZZ DO NOT USE - USR-REG-N07-NDMIS-WRITER Reporting group
-objectClass: groupOfNames
-member: cn=placeholder
-
-dn: cn=USR-REG-N07-NDMIS-MANAGER Reporting group,ou=NDMIS-Reporting,{{ ldap_config.base_groups }}
-cn: USR-REG-N07-NDMIS-MANAGER Reporting group
-description: ZZ DO NOT USE - USR-REG-N07-NDMIS-MANAGER Reporting group
-objectClass: groupOfNames
-member: cn=placeholder
-
-dn: cn=USR-REG-N07-NDMIS-READER Reporting group,ou=NDMIS-Reporting,{{ ldap_config.base_groups }}
-cn: USR-REG-N07-NDMIS-READER Reporting group
-description: ZZ DO NOT USE - USR-REG-N07-NDMIS-READER Reporting group
 objectClass: groupOfNames
 member: cn=placeholder


### PR DESCRIPTION
(groups with description prefixed with 'ZZ DO NOT USE')

Note: this will not remove the groups from the LDAP directory, it just ensures they aren't recreated. The groups should be removed manually in each environment.