### PR TITLE
ALS-3748 Add LDAP groups

### DIFF
--- a/groups/reporting-groups.ldif.j2
+++ b/groups/reporting-groups.ldif.j2
@@ -1322,3 +1322,27 @@ cn: USR-EPS-NDMIS-WRITER Reporting group
 description: USR-EPS-NDMIS-WRITER Reporting group
 objectClass: groupOfNames
 member: cn=placeholder
+
+dn: cn=USR-ALL-DFI-Access to the NDMIS DFI Reports folder,ou=NDMIS-Reporting,{{ ldap_config.base_groups }}
+cn: USR-ALL-DFI-Access to the NDMIS DFI Reports folder
+description: USR-ALL-DFI-Access to the NDMIS DFI Reports folder
+objectClass: groupOfNames
+member: cn=placeholder
+
+dn: cn=USR-DFI-NDMIS-WRITER Reporting group,ou=NDMIS-Reporting,{{ ldap_config.base_groups }}
+cn: USR-DFI-NDMIS-WRITER Reporting group
+description: USR-DFI-NDMIS-WRITER Reporting group
+objectClass: groupOfNames
+member: cn=placeholder
+
+dn: cn=USR-DFI-NDMIS-MANAGER Reporting group,ou=NDMIS-Reporting,{{ ldap_config.base_groups }}
+cn: USR-DFI-NDMIS-MANAGER Reporting group
+description: USR-DFI-NDMIS-MANAGER Reporting group
+objectClass: groupOfNames
+member: cn=placeholder
+
+dn: cn=USR-DFI-NDMIS-READER Reporting group,ou=NDMIS-Reporting,{{ ldap_config.base_groups }}
+cn: USR-DFI-NDMIS-READER Reporting group
+description: USR-DFI-NDMIS-READER Reporting group
+objectClass: groupOfNames
+member: cn=placeholder


### PR DESCRIPTION
 for controlling access to the DFI (Dynamic Framework Interventions) reporting folders in MIS