### PR TITLE
Set email address for test user

### DIFF
--- a/users/all-access-user.ldif.j2
+++ b/users/all-access-user.ldif.j2
@@ -1,7 +1,7 @@
 dn:cn={{ username }},{{ ldap_config.base_users }}
 cn:{{ username }}
 uid:{{ username }}
-mail:{{ username }}
+mail:simulate-delivered@notifications.service.gov.uk
 description:{{ username}}
 givenname:{{ username }}
 sn:{{ username }}


### PR DESCRIPTION
This is to prevent gov.uk notify errors in Manage a Workforce, by using one of the test email addresses. See https://docs.notifications.service.gov.uk/rest-api.html#email-addresses